### PR TITLE
use local jshint module

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "python -m SimpleHTTPServer",
     "test": "npm run lint && google-chrome http://localhost:8000/test/phantom/testrunner.html",
-    "lint": "jshint -c .jshintrc src/*"
+    "lint": "./node_modules/jshint/bin/jshint -c .jshintrc src/*"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
If the host machine does not have jshint installed in $PATH the linting would not work. As jshint is installed as a local node module I changed the "npm run lint" command to use the local module.